### PR TITLE
Added getServerStatus function

### DIFF
--- a/client/Client.js
+++ b/client/Client.js
@@ -85,6 +85,20 @@ class Client {
     }
 
     /**
+     * Gets a server's status, so whether it is running, starting or powered off
+     *
+     * @param serverId
+     * @returns {Promise<unknown>}
+     */
+     getServerStatus(serverId) {
+        return new Promise((res, rej) => {
+            Methods.getServerStatus(this.hostUrl, this.apiKey, serverId).then((response) => {
+                return res(response.data.attributes.current_state);
+            }).catch(err => rej(this.processError(err)));
+        })
+    }
+
+    /**
      * Gets a list of servers from your panel, currently this only get the first page but i will add support for grabbing ALL pages with this methods
      *
      * @returns {Promise<unknown>}

--- a/client/methods/Methods.js
+++ b/client/methods/Methods.js
@@ -16,6 +16,11 @@ exports.getServerDetails = (host, key, serverId) => {
     return req.executeGet(ClientRequest.GET_SERVER_INFO(serverId));
 };
 
+exports.getServerStatus = (host, key, serverId) => {
+    let req = new NodeactylRequest(host, key);
+    return req.executeGet(ClientRequest.GET_SERVER_STATUS(serverId));
+};
+
 exports.getAllServers = (host, key) => {
     let req = new NodeactylRequest(host, key);
     return req.executeGet(ClientRequest.GET_ALL_SERVERS);

--- a/utils/ClientRequest.js
+++ b/utils/ClientRequest.js
@@ -9,6 +9,13 @@ module.exports = {
     GET_SERVER_INFO(serverId) {
         return `CLIENT_GET_SERVER_INFO:${serverId}`;
     },
+    GET_SERVER_STATUS_META: "CLIENT_GET_SERVER_STATUS",
+    /**
+     * @return {string}
+     */
+    GET_SERVER_STATUS(serverId) {
+        return `CLIENT_GET_SERVER_STATUS:${serverId}`;
+    },
     GET_ALL_SERVERS: "CLIENT_GET_ALL_SERVERS",
     /**
      * @return {string}

--- a/utils/NodeactylRequest.js
+++ b/utils/NodeactylRequest.js
@@ -152,6 +152,10 @@ class NodeactylRequest {
             if (str[1] === "" || str[1] === undefined) throw new Error("Could not split enum to a length of 2 when using GET_SERVER_INFO (contact a developer)");
             return `api/client/servers/${str[1]}`
 
+        } else if (request === ClientRequest.GET_SERVER_STATUS_META) {
+            if (str[1] === "" || str[1] === undefined) throw new Error("Could not split enum to a length of 2 when using GET_SERVER_INFO (contact a developer)");
+            return `api/client/servers/${str[1]}/resources`
+
         } else if (isPowerAction) {
             if (str[1] === "" || str[1] === undefined) throw new Error("Could not split enum to a length of 2 when using typeof POWER_ACTION (contact a developer)");
             return `api/client/servers/${str[1]}/power`;


### PR DESCRIPTION
This adds the getServerStatus() function to Nodeactyl. It has been made upon request of Sceptor#6503 from the Discord support server. It has been tested to a real Pterodactyl panel and I have confirmed that everything works.

It literally just returns the status that the Pterodactyl API gives it in a string. For as far as I have seen during testing, these can be:

- 'starting'
- 'stopped'
- 'running'

(there are probably more status indicators, but these are the ones I have seen)